### PR TITLE
Add a swagger-plugin directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.1.0
+
+* Add a `swagger-plugin` directive:
+
+  * Automatically copy the specification YAML file to the HTML static path.
+  * Insert the Swagger JavaScript and CSS tags in the `<head>` element of the HTML page.
+  * Does not require the `swagger` configuration in the `conf.py` file.
+
 ## 4.0.0
 
 * Add support for python 3.13

--- a/README.md
+++ b/README.md
@@ -11,24 +11,26 @@ It can generate one or multiple swagger HTML pages with a custom configuration t
 
 Just run `pip install swagger-plugin-for-sphinx`
 
-
 ## Usage
 
-### Enable the plugin
+### Enable the Plugin
 
 First, add the plugin to the extensions list:
+
 ```python
 extensions = ["swagger_plugin_for_sphinx"]
 ```
 
-### Global configuration
+### Global Configuration
 
 Then add the main configuration for swagger:
+
 ```python
 swagger_present_uri = ""
 swagger_bundle_uri = ""
 swagger_css_uri = ""
 ```
+
 These correspond to the modules explained [here](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/installation.md).
 By default, the latest release is used from [here](https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest).
 
@@ -36,8 +38,46 @@ Note, that also file paths can be used.
 First, specify your paths in the `html_static_path` config of sphinx.
 Then customize the corresponding uri settings like `_static/<myfile>`
 
-### Standalone page
+### Swagger Plugin Page
+
+To include a Swagger API specification into an HTML page specify the `swagger-plugin` directive and the relative path to the specification:
+
+````code
+# Markdown
+```{swagger-plugin} path/to/spec.yaml
+```
+
+# RST
+.. swagger-plugin:: path/to/spec.yaml
+````
+
+The directive performs the following actions:
+
+- Adds the Swagger JavaScript and CSS files to the HTML page.
+- Adds the Swagger configuration to the HTML page.
+- Adds the specification YAML file to the `html_static_path`.
+
+In contrast with the `inline-swagger` directive, you do not need to add the `swagger`
+configuration in your `conf.py` file.
+
+By default, the directive creates a `<div>` element with the ID `swagger-ui-container`.
+If you put more than one `swagger-plugin` directive in a file, specify unique IDs, like the following example:
+
+````code
+# Markdown
+```{swagger-plugin} path/to/one.yaml
+:id: spec-one
+```
+
+```{swagger-plugin} path/to/two.yaml
+:id: spec-two
+```
+````
+
+### Standalone Page
+
 As a last step, define the swagger configuration as follows:
+
 ```python
 swagger = [
     {
@@ -50,6 +90,7 @@ swagger = [
     }
 ]
 ```
+
 Each item on the list will generate a new swagger HTML page.
 The `name` is the HTML page name and `page` defines the file name without an extension. This needs to be included in the TOC.
 The `options` are then used for the `SwaggerUIBundle` as defined [here](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md).
@@ -57,7 +98,8 @@ Please don't specify the `dom_id` since it's hardcoded in the HTML page.
 If the specification is provided as a file, don't forget to copy it (e.g., by putting it into the `html_static_path`).
 To silence the warning `toctree contains reference to nonexisting document`, just put a dummy file with the same name as `page` into the source folder.
 
-## Inline swagger page
+## Inline Swagger Page
+
 To include a swagger page into a sphinx page use the directive ``inline-swagger``:
 
 ```rst
@@ -65,9 +107,9 @@ To include a swagger page into a sphinx page use the directive ``inline-swagger`
     :id: my-page
 ```
 
-The ``id`` links to an existing configuration in ``conf.py`` as shows above.
-In this case, the configuration ``page`` will be ignored.
-Behind the scenes, a swagger HTML page is generated and then inserted using the ``.. raw::``
+The ``id`` links to an existing configuration in ``conf.py`` as shown in the standalone page section.
+In this case, the configuration ``page`` is ignored.
+The extension creates an HTML page and inserts the Swagger configuration using the ``.. raw::``
 directive.
 
 ## Build and Publish

--- a/README.md
+++ b/README.md
@@ -42,14 +42,9 @@ Then customize the corresponding uri settings like `_static/<myfile>`
 
 To include a Swagger API specification into an HTML page specify the `swagger-plugin` directive and the relative path to the specification:
 
-````code
-# Markdown
-```{swagger-plugin} path/to/spec.yaml
-```
-
-# RST
+```code
 .. swagger-plugin:: path/to/spec.yaml
-````
+```
 
 The directive performs the following actions:
 
@@ -63,16 +58,13 @@ configuration in your `conf.py` file.
 By default, the directive creates a `<div>` element with the ID `swagger-ui-container`.
 If you put more than one `swagger-plugin` directive in a file, specify unique IDs, like the following example:
 
-````code
-# Markdown
-```{swagger-plugin} path/to/one.yaml
-:id: spec-one
-```
+```code
+.. swagger-plugin:: path/to/one.yaml
+   :id: spec-one
 
-```{swagger-plugin} path/to/two.yaml
-:id: spec-two
+.. swagger-plugin:: path/to/two.yaml
+   :id: spec-two
 ```
-````
 
 ### Standalone Page
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swagger-plugin-for-sphinx"
-version = "4.0.0"
+version = "4.1.0"
 description = "Sphinx plugin which renders a OpenAPI specification with Swagger"
 authors = [{ name = "Kai Harder", email = "kai.harder@sap.com" }]
 readme = "README.md"

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -72,7 +72,13 @@ class SwaggerPluginDirective(SphinxDirective):
         return [node]
 
 
-def add_css_js(app: Sphinx, pagename: str) -> None:
+def add_css_js(
+    app: Sphinx,
+    pagename: str,
+    _template: str,
+    _context: dict[str, Any],
+    _doctree: nodes.document,
+) -> None:
     """Add Swagger CSS and JS to pages with swagger-plugin directive."""
 
     if "swagger_plugin" not in app.env.metadata[pagename]:

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -41,7 +41,6 @@ class SwaggerPluginDirective(SphinxDirective):
                 f"{app.env.doc2path(app.env.docname)}:{self.lineno}."
             )
 
-        # TODO: HTTP URLs
         relpath, abspath = self.env.relfn2path(self.arguments[0])
         spec = Path(abspath).resolve()
         if not spec.exists():

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -84,7 +84,6 @@ def add_css_js(
     _doctree: nodes.document,
 ) -> None:
     """Add Swagger CSS and JS to pages with swagger-plugin directive."""
-
     if "swagger_plugin" not in app.env.metadata[pagename]:
         return
 

--- a/swagger_plugin_for_sphinx/plugin_directive.j2
+++ b/swagger_plugin_for_sphinx/plugin_directive.j2
@@ -1,0 +1,9 @@
+
+window.onload = () => {
+  {% for spec in specs %}
+  window.ui = SwaggerUIBundle({
+    url: "{{ spec.url_path }}",
+    dom_id: "#{{ spec.div_id }}",
+  })
+  {% endfor %}
+}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -10,6 +10,7 @@ from typing import Any, Callable
 
 import pytest
 from sphinx.application import Sphinx
+from sphinx.errors import ExtensionError
 
 SphinxRunner = Callable[..., None]
 
@@ -123,6 +124,111 @@ def test_inline(sphinx_runner: SphinxRunner, tmp_path: Path) -> None:
 
     assert "sphinx" in html
     assert "window.ui = SwaggerUIBundle(config);" in html
+
+
+def test_swagger_plugin_directive(sphinx_runner: SphinxRunner, tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    index_file = docs / "index.rst"
+    index_file.write_text(
+        "Project\n=======\n\n.. toctree::\n   api.rst",
+        encoding="utf-8",
+    )
+    api_file = docs / "api.rst"
+    api_file.write_text(
+        "API\n===\n\n.. swagger-plugin:: _static/yaml/openapi.yaml\n   :id: pet-store\n",
+        encoding="utf-8",
+    )
+
+    spec = Path(__file__).parent / "test_data" / "_static" / "openapi.yml"
+    dest = docs / "_static" / "yaml" / "openapi.yaml"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(spec.read_text())
+
+    sphinx_runner(swagger=[])
+
+    build = tmp_path / "build"
+    with open(build / "api.html", encoding="utf-8") as file:
+        html = file.read()
+
+    assert "sphinx" in html
+    assert "https://cdn.jsdelivr.net" in html
+    assert "_static/yaml/openapi.yaml" in html
+    assert "#pet-store" in html
+    assert "window.ui = SwaggerUIBundle(config);" in html
+
+    spec = tmp_path / "build" / "_static" / "yaml" / "openapi.yaml"
+    assert spec.exists()
+
+
+def test_swagger_plugin_directive_same_dir(
+    sphinx_runner: SphinxRunner, tmp_path: Path
+) -> None:
+    docs = tmp_path / "docs"
+    index_file = docs / "index.rst"
+    index_file.write_text(
+        "Project\n=======\n\n.. toctree::\n   api.rst",
+        encoding="utf-8",
+    )
+    api_file = docs / "api.rst"
+    api_file.write_text(
+        "API\n===\n\n.. swagger-plugin:: openapi.yaml\n",
+        encoding="utf-8",
+    )
+
+    spec = Path(__file__).parent / "test_data" / "_static" / "openapi.yml"
+    dest = docs / "openapi.yaml"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(spec.read_text())
+
+    sphinx_runner(swagger=[])
+
+    build = tmp_path / "build"
+    with open(build / "api.html", encoding="utf-8") as file:
+        html = file.read()
+
+    assert "_static/openapi.yaml" in html
+    assert "#swagger-ui-container" in html
+
+    spec = tmp_path / "build" / "_static" / "openapi.yaml"
+    assert spec.exists()
+
+
+def test_swagger_plugin_directive_exception(
+    sphinx_runner: SphinxRunner, tmp_path: Path
+) -> None:
+    docs = tmp_path / "docs"
+    api_file = docs / "api.rst"
+    api_file.write_text(
+        "API\n===\n\n.. swagger-plugin:: openapi.yaml\n   :id: pet-store\n",
+        encoding="utf-8",
+    )
+    index_file = docs / "index.rst"
+    index_file.write_text(
+        "Project\n=======\n\n.. toctree::\n   api.rst",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ExtensionError, match="file not found: openapi.yaml"):
+        sphinx_runner(swagger=[])
+
+
+def test_swagger_plugin_directive_no_arg(
+    sphinx_runner: SphinxRunner, tmp_path: Path
+) -> None:
+    docs = tmp_path / "docs"
+    api_file = docs / "api.rst"
+    api_file.write_text(
+        "API\n===\n\n.. swagger-plugin::\n   :id: pet-store\n",
+        encoding="utf-8",
+    )
+    index_file = docs / "index.rst"
+    index_file.write_text(
+        "Project\n=======\n\n.. toctree::\n   api.rst",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ExtensionError, match="docs/api.rst:4"):
+        sphinx_runner(swagger=[])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Specify path to YAML in new directive.
- Rely on html_static_path extend to copy files.
- Put CSS and JS on pages with directive only.

Fixes https://github.com/SAP/swagger-plugin-for-sphinx/issues/186.