### PR TITLE
fix: edge case with spec path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.2
+
+* Fix some errors when the spec is in a subdirectory and not in the same folder as the file referncing it.
+
 ## 5.0.1
 
 * Fix some errors when the spec is in a subdirectory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swagger-plugin-for-sphinx"
-version = "5.0.1"
+version = "5.0.2"
 description = "Sphinx plugin which renders a OpenAPI specification with Swagger"
 authors = [{ name = "Kai Harder", email = "kai.harder@sap.com" }]
 readme = "README.md"

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -14,7 +14,6 @@ from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
-from sphinx.util.fileutil import copy_asset_file
 
 logger = logging.getLogger(__name__)
 _HERE = Path(__file__).parent.resolve()

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -61,7 +61,7 @@ class SwaggerPluginDirective(SphinxDirective):
         url_path = (
             "../".join(["" for _ in range(len(rel_parts))])
             + "_static/"
-            + self.arguments[0]
+            + rel_parts[-1]
         )
 
         config = {

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -57,9 +57,7 @@ class SwaggerPluginDirective(SphinxDirective):
 
         spec_file = Path(spec_abspath).name
         logger.info(f"Adding to html_static_path: {spec}.")
-        if app.builder.format == 'html':
-            staticdir = Path(app.builder.outdir).joinpath('_static')
-            copy_asset_file(spec, staticdir)
+        app.config.html_static_path.extend([spec])
 
 
         url_path = (


### PR DESCRIPTION
There's a small issue with the way the spec file is declared in `url_path`. If the referencing directive uses a relative path, as mentioned in the documentation (`.. swagger-plugin:: path/to/spec.yaml`) then the referenced `url_path` becomes `_build/_static/path/to/spec.yaml`, when the file when added to the static path is located in the `_static` folder (`_build/_static/spec.yaml`).

By appending `rel_parts[-1]` to the `url_path` instead of `self.arguments[0]` it should fix this.

Initial testing shows success, but I haven't tested every case (and I didn't do it in a clean environment for each different case - I just tested various cases in the same set of docs).

Side note: It's also likely that there will be conflicts if someone has multiple API specifications with the same filename - as they will all be added to the `_static` directory, but I assume that won't come up much.