### PR TITLE
feat: support for dirhtml builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.3
+
+* Fixed an issue causing a spec to be linked incorrectly when the `dirhtml` builder is used.
+
 ## 5.0.2
 
 * Fixed an issue causing a spec to be linked incorrectly when the source document is in a subfolder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swagger-plugin-for-sphinx"
-version = "5.0.2"
+version = "5.0.3"
 description = "Sphinx plugin which renders a OpenAPI specification with Swagger"
 authors = [{ name = "Kai Harder", email = "kai.harder@sap.com" }]
 readme = "README.md"

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -39,7 +39,11 @@ class SwaggerPluginDirective(SphinxDirective):
         app: Sphinx = self.state.document.settings.env.app
         metadata = self.env.metadata[self.env.docname]
         configs = metadata.setdefault("swagger_plugin", [])
-        path_offset = 1 if app.builder.name == "dirhtml" and app.env.docname.split("/") != ['index'] else 0
+        path_offset = (
+            1
+            if app.builder.name == "dirhtml" and app.env.docname.split("/") != ["index"]
+            else 0
+        )
 
         if len(self.arguments) != 1:
             raise ExtensionError(
@@ -59,7 +63,9 @@ class SwaggerPluginDirective(SphinxDirective):
         app.config.html_static_path.extend([spec])
 
         url_path = (
-            "../".join(["" for _ in range(len(app.env.docname.split("/")) + path_offset)])
+            "../".join(
+                ["" for _ in range(len(app.env.docname.split("/")) + path_offset)]
+            )
             + "_static/"
             + spec.name
         )

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -39,10 +39,7 @@ class SwaggerPluginDirective(SphinxDirective):
         app: Sphinx = self.state.document.settings.env.app
         metadata = self.env.metadata[self.env.docname]
         configs = metadata.setdefault("swagger_plugin", [])
-        path_offset = 0
-
-        if app.builder.name == "dirhtml" and app.env.docname.split("/") != ['index']:
-            path_offset = 1
+        path_offset = 1 if app.builder.name == "dirhtml" and app.env.docname.split("/") != ['index'] else 0
 
         if len(self.arguments) != 1:
             raise ExtensionError(

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -39,6 +39,10 @@ class SwaggerPluginDirective(SphinxDirective):
         app: Sphinx = self.state.document.settings.env.app
         metadata = self.env.metadata[self.env.docname]
         configs = metadata.setdefault("swagger_plugin", [])
+        path_offset = 0
+
+        if app.builder.name == "dirhtml" and app.env.docname.split("/") != ['index']:
+            path_offset = 1
 
         if len(self.arguments) != 1:
             raise ExtensionError(
@@ -58,7 +62,7 @@ class SwaggerPluginDirective(SphinxDirective):
         app.config.html_static_path.extend([spec])
 
         url_path = (
-            "../".join(["" for _ in range(len(app.env.docname.split("/")))])
+            "../".join(["" for _ in range(len(app.env.docname.split("/")) + path_offset)])
             + "_static/"
             + spec.name
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -45,15 +45,17 @@ def test_basic() -> None:
             _check_page_title(browser, "subfolder/p2", ["Swagger Petstore in Specs"])
         finally:
             popen.terminate()
-            
+
+
 @pytest.mark.integration
 def test_dirhtml() -> None:
     """Test a dirhtml scenario."""
     shutil.rmtree("tests/test_data/_build", ignore_errors=True)
     subprocess.run(
-        ["sphinx-build", "-M", "dirhtml", "tests/test_data", "tests/test_data/_build"], check=True
+        ["sphinx-build", "-M", "dirhtml", "tests/test_data", "tests/test_data/_build"],
+        check=True,
     )
-    
+
     options = webdriver.ChromeOptions()
     options.add_argument("--ignore-certificate-errors")
 
@@ -77,9 +79,12 @@ def test_dirhtml() -> None:
                 "subfolder/p1",
                 ["Swagger Petstore in Subfolder", "Swagger Petstore in Main"],
             )
-            _check_page_title_dirhtml(browser, "subfolder/p2", ["Swagger Petstore in Specs"])
+            _check_page_title_dirhtml(
+                browser, "subfolder/p2", ["Swagger Petstore in Specs"]
+            )
         finally:
             popen.terminate()
+
 
 def _check_page_title(
     browser: webdriver.Remote, page: str, expected_title: list[str]
@@ -88,6 +93,7 @@ def _check_page_title(
     elements = browser.find_elements(By.CLASS_NAME, "title")
     titles = [element.text.split("\n")[0] for element in elements]
     assert titles == expected_title
+
 
 def _check_page_title_dirhtml(
     browser: webdriver.Remote, page: str, expected_title: list[str]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,7 +85,7 @@ def test_dirhtml() -> None:
 def _check_page_title(
     browser: webdriver.Remote, page: str, expected_title: list[str]
 ) -> None:
-    browser.get(f"http://{get_ip()}:8000/{page}.html")
+    browser.get(f"http://localhost:8000/{page}.html")
     elements = browser.find_elements(By.CLASS_NAME, "title")
     titles = [element.text.split("\n")[0] for element in elements]
     assert titles == expected_title
@@ -94,20 +94,7 @@ def _check_page_title_dirhtml(
     browser: webdriver.Remote, page: str, expected_title: list[str]
 ) -> None:
     print(page)
-    browser.get(f"http://{get_ip()}:8000/{page}/")
+    browser.get(f"http://localhost:8000/{page}/")
     elements = browser.find_elements(By.CLASS_NAME, "title")
     titles = [element.text.split("\n")[0] for element in elements]
     assert titles == expected_title
-
-def get_ip():
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.settimeout(0)
-    try:
-        # doesn't even have to be reachable
-        s.connect(('10.254.254.254', 1))
-        IP = s.getsockname()[0]
-    except Exception:
-        IP = '127.0.0.1'
-    finally:
-        s.close()
-    return IP

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,9 +10,10 @@ import pytest
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 
+import socket
 
 @pytest.mark.integration
-def test() -> None:
+def test_basic() -> None:
     """Test a basic scenario."""
     shutil.rmtree("tests/test_data/_build", ignore_errors=True)
     subprocess.run(
@@ -45,12 +46,68 @@ def test() -> None:
             _check_page_title(browser, "subfolder/p2", ["Swagger Petstore in Specs"])
         finally:
             popen.terminate()
+            
+@pytest.mark.integration
+def test_dirhtml() -> None:
+    """Test a dirhtml scenario."""
+    shutil.rmtree("tests/test_data/_build", ignore_errors=True)
+    subprocess.run(
+        ["sphinx-build", "-M", "dirhtml", "tests/test_data", "tests/test_data/_build"], check=True
+    )
+    
+    options = webdriver.ChromeOptions()
+    options.add_argument("--ignore-certificate-errors")
 
+    with (
+        webdriver.Remote("http://localhost:4444", options=options) as browser,
+        subprocess.Popen(
+            [
+                "python",
+                "-m",
+                "http.server",
+                "--directory",
+                "tests/test_data/_build/dirhtml",
+            ]
+        ) as popen,
+    ):
+        time.sleep(5)
+        try:
+            _check_page_title_dirhtml(browser, "openapi", ["Swagger Petstore in Main"])
+            _check_page_title_dirhtml(
+                browser,
+                "subfolder/p1",
+                ["Swagger Petstore in Subfolder", "Swagger Petstore in Main"],
+            )
+            _check_page_title_dirhtml(browser, "subfolder/p2", ["Swagger Petstore in Specs"])
+        finally:
+            popen.terminate()
 
 def _check_page_title(
     browser: webdriver.Remote, page: str, expected_title: list[str]
 ) -> None:
-    browser.get(f"http://localhost:8000/{page}.html")
+    browser.get(f"http://{get_ip()}:8000/{page}.html")
     elements = browser.find_elements(By.CLASS_NAME, "title")
     titles = [element.text.split("\n")[0] for element in elements]
     assert titles == expected_title
+
+def _check_page_title_dirhtml(
+    browser: webdriver.Remote, page: str, expected_title: list[str]
+) -> None:
+    print(page)
+    browser.get(f"http://{get_ip()}:8000/{page}/")
+    elements = browser.find_elements(By.CLASS_NAME, "title")
+    titles = [element.text.split("\n")[0] for element in elements]
+    assert titles == expected_title
+
+def get_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(0)
+    try:
+        # doesn't even have to be reachable
+        s.connect(('10.254.254.254', 1))
+        IP = s.getsockname()[0]
+    except Exception:
+        IP = '127.0.0.1'
+    finally:
+        s.close()
+    return IP

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,7 +10,6 @@ import pytest
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 
-import socket
 
 @pytest.mark.integration
 def test_basic() -> None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -152,7 +152,6 @@ def test_swagger_plugin_directive_same_dir(
 
     assert "_static/openapi.yaml" in html
     assert "#swagger-ui-container" in html
-    assert "Failed to load API definition." not in html
 
     spec = tmp_path / "build" / "_static" / "openapi.yaml"
     assert spec.exists()
@@ -168,7 +167,6 @@ def test_swagger_plugin_dirhtml(
 
     assert "_static/openapi.yaml" in html
     assert "#swagger-ui-container" in html
-    assert "Failed to load API definition." not in html
 
     spec = tmp_path / "build" / "_static" / "openapi.yaml"
     assert spec.exists()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -28,6 +28,7 @@ def sphinx_runner(tmp_path: Path) -> SphinxRunner:
         swagger_present_uri: str | None = None,
         swagger_bundle_uri: str | None = None,
         swagger_css_uri: str | None = None,
+        sphinx_builder: str | None = "html"
     ) -> None:
         code = ["extensions = ['swagger_plugin_for_sphinx']"]
         if swagger_present_uri:
@@ -61,7 +62,7 @@ def sphinx_runner(tmp_path: Path) -> SphinxRunner:
             confdir=str(docs),
             outdir=str(build),
             doctreedir=str(build / ".doctrees"),
-            buildername="html",
+            buildername=sphinx_builder,
         ).build()
 
     return run
@@ -151,6 +152,23 @@ def test_swagger_plugin_directive_same_dir(
 
     assert "_static/openapi.yaml" in html
     assert "#swagger-ui-container" in html
+    assert "Failed to load API definition." not in html
+
+    spec = tmp_path / "build" / "_static" / "openapi.yaml"
+    assert spec.exists()
+
+def test_swagger_plugin_dirhtml(
+    sphinx_runner: SphinxRunner, tmp_path: Path
+) -> None:
+    sphinx_runner(directive=".. swagger-plugin:: openapi.yaml", sphinx_builder="dirhtml")
+
+    build = tmp_path / "build"
+    with open(build / "api/index.html", encoding="utf-8") as file:
+        html = file.read()
+
+    assert "_static/openapi.yaml" in html
+    assert "#swagger-ui-container" in html
+    assert "Failed to load API definition." not in html
 
     spec = tmp_path / "build" / "_static" / "openapi.yaml"
     assert spec.exists()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -28,7 +28,7 @@ def sphinx_runner(tmp_path: Path) -> SphinxRunner:
         swagger_present_uri: str | None = None,
         swagger_bundle_uri: str | None = None,
         swagger_css_uri: str | None = None,
-        sphinx_builder: str | None = "html"
+        sphinx_builder: str = "html",
     ) -> None:
         code = ["extensions = ['swagger_plugin_for_sphinx']"]
         if swagger_present_uri:
@@ -156,10 +156,11 @@ def test_swagger_plugin_directive_same_dir(
     spec = tmp_path / "build" / "_static" / "openapi.yaml"
     assert spec.exists()
 
-def test_swagger_plugin_dirhtml(
-    sphinx_runner: SphinxRunner, tmp_path: Path
-) -> None:
-    sphinx_runner(directive=".. swagger-plugin:: openapi.yaml", sphinx_builder="dirhtml")
+
+def test_swagger_plugin_dirhtml(sphinx_runner: SphinxRunner, tmp_path: Path) -> None:
+    sphinx_runner(
+        directive=".. swagger-plugin:: openapi.yaml", sphinx_builder="dirhtml"
+    )
 
     build = tmp_path / "build"
     with open(build / "api/index.html", encoding="utf-8") as file:


### PR DESCRIPTION
Fixes #197. 

`dirhtml` builds nest all files in an additional folder save for the root `index.html`. This change checks for a `dirhtml` build and applies an offset for all files save for the root `index.html`.

Spec is now located in both `html` and `dirhtml` builds.