### PR TITLE
Refactor spec file handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,4 @@ cython_debug/
 .history
 .ionide
 
-tests/test_data/_build/
+tests/*/_build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.1.0
+
+* Refactored copying the specification to the HTML output and
+  referencing the path to the specification in the HTML page.
+* Preserves the source directory structure like `docs/api/foo/openapi.yaml`
+  and `docs/api/bar/openapi.yaml` so that different files can use
+  the same file name.
+
 ## 5.0.3
 
 * Fixed an issue causing a spec to be linked incorrectly when the `dirhtml` builder is used.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The directive supports the following options
 * `full-page`: if set, all other content on the page is dropped and only the Swagger part is rendered
 * `page-title`: the name of the HTML page if `full-page` is specified
 * `swagger-options`: JSON string that is passed to Swagger to enable additional options as described
-    on the [configuration](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md)
+    on the [configuration](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/)
     page of the Swagger documentation.
 
 By default, the directive creates a `<div>` element with the ID `swagger-ui-container`.

--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ and the relative path to the specification:
 .. swagger-plugin:: path/to/spec.yaml
 ```
 
-The spec is automatically copied into the `html_static_path`.
+The spec is automatically copied into the `_static` build output directory.
 
 The directive supports the following options
 
-* `id`: specifies an unique id for the specifiction per page (see below)
-* `full-page`: if set, all other content on the page is dropped and only the swagger part is rendered
-* `page-title`: the name of the HTML page if `full-page` is used
-* `swagger-options`: JSON string which is passed to swagger to enable additional options as described
-    [here](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md)
-
+* `id`: specifies an unique ID for the specification per page (see below)
+* `full-page`: if set, all other content on the page is dropped and only the Swagger part is rendered
+* `page-title`: the name of the HTML page if `full-page` is specified
+* `swagger-options`: JSON string that is passed to Swagger to enable additional options as described
+    on the [configuration](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md)
+    page of the Swagger documentation.
 
 By default, the directive creates a `<div>` element with the ID `swagger-ui-container`.
 If you put more than one `swagger-plugin` directive in a file, specify unique IDs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swagger-plugin-for-sphinx"
-version = "5.0.3"
+version = "5.1.0"
 description = "Sphinx plugin which renders a OpenAPI specification with Swagger"
 authors = [{ name = "Kai Harder", email = "kai.harder@sap.com" }]
 readme = "README.md"

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -40,8 +40,8 @@ class SwaggerPluginDirective(SphinxDirective):
         app: Sphinx = self.state.document.settings.env.app
         metadata = self.env.metadata[self.env.docname]
         configs = metadata.setdefault("swagger_plugin", [])
-        # The static dir is set during builder init and not available from a variable or function.
-        # https://github.com/sphinx-doc/sphinx/blob/master/sphinx/builders/html/__init__.py#L137
+        # The static dir is created by Sphinx and is not available from a variable or function.
+        # https://github.com/sphinx-doc/sphinx/blob/v8.1.3/sphinx/builders/html/__init__.py#L897
         static_dir = Path(app.builder.outdir).joinpath("_static")
         path_offset = (
             1

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -42,7 +42,7 @@ class SwaggerPluginDirective(SphinxDirective):
         configs = metadata.setdefault("swagger_plugin", [])
         # The static dir is set during builder init and not available from a variable or function.
         # https://github.com/sphinx-doc/sphinx/blob/master/sphinx/builders/html/__init__.py#L137
-        static_dir = Path(app.builder.outdir / "_static")
+        static_dir = Path(app.builder.outdir).joinpath("_static")
         path_offset = (
             1
             if app.builder.name == "dirhtml" and app.env.docname.split("/") != ["index"]
@@ -67,8 +67,8 @@ class SwaggerPluginDirective(SphinxDirective):
 
         # Preserve the source directory structure to avoid name collisions.
         outfile = static_dir.joinpath(relpath)
-        ensuredir(outfile.parent)
-        copyfile(spec, outfile)
+        ensuredir(str(outfile.parent))
+        copyfile(str(spec), str(outfile))
 
         # The range - 1 is to skip the RST or MD document itself.
         url_path = (

--- a/tests/test_subdirs/conf.py
+++ b/tests/test_subdirs/conf.py
@@ -1,0 +1,14 @@
+# pylint: disable=invalid-name
+
+"""Configuration for sphinx."""
+
+from __future__ import annotations
+
+# -- Project information -----------------------------------------------------
+project = "Subdirs Integration Test Documentation"
+release = "1.0.0"
+version = "1.0.0"
+
+# -- General configuration ---------------------------------------------------
+
+extensions = ["swagger_plugin_for_sphinx"]

--- a/tests/test_subdirs/index.rst
+++ b/tests/test_subdirs/index.rst
@@ -1,0 +1,12 @@
+Subdirectory Gymnastics
+=======================
+
+Integration test to confirm directory traversal to specifications up and down
+the directory tree are referenced correctly.
+
+.. toctree::
+   :maxdepth: 1
+
+   openapi
+   stores/petstore
+   stores/rockstore/rockstore

--- a/tests/test_subdirs/openapi.rst
+++ b/tests/test_subdirs/openapi.rst
@@ -1,0 +1,6 @@
+OpenAPI Specification
+=====================
+
+.. swagger-plugin:: openapi_main.yml
+    :full-page:
+    :page-title: Swagger Petstore

--- a/tests/test_subdirs/openapi_main.yml
+++ b/tests/test_subdirs/openapi_main.yml
@@ -1,0 +1,119 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore in Main
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+        required: true
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/test_subdirs/specs/petstore/openapi_specs.yml
+++ b/tests/test_subdirs/specs/petstore/openapi_specs.yml
@@ -1,0 +1,119 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore in Specs
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+        required: true
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/test_subdirs/specs/rockstore/openapi_specs.yml
+++ b/tests/test_subdirs/specs/rockstore/openapi_specs.yml
@@ -1,0 +1,119 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Rockstore in Specs
+  license:
+    name: MIT
+servers:
+  - url: http://rockstore.swagger.io/v1
+paths:
+  /rocks:
+    get:
+      summary: List all rocks
+      operationId: listRocks
+      tags:
+        - rocks
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of rocks
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Rocks"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a rock
+      operationId: createRocks
+      tags:
+        - rocks
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Rock'
+        required: true
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /rocks/{petId}:
+    get:
+      summary: Info for a specific rock
+      operationId: showRockById
+      tags:
+        - rocks
+      parameters:
+        - name: rockId
+          in: path
+          required: true
+          description: The id of the rock to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Rock"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Rock:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Rocks:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/Rock"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/test_subdirs/stores/openapi_samedir.yml
+++ b/tests/test_subdirs/stores/openapi_samedir.yml
@@ -1,0 +1,119 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore in Samedir
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+        required: true
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/test_subdirs/stores/petstore.rst
+++ b/tests/test_subdirs/stores/petstore.rst
@@ -1,0 +1,8 @@
+OpenAPI Specification for Petstore
+==================================
+
+.. swagger-plugin:: ../specs/petstore/openapi_specs.yml
+   :id: petstore-subdir
+
+.. swagger-plugin:: openapi_samedir.yml
+   :id: petstore-samedir

--- a/tests/test_subdirs/stores/rockstore/rockstore.rst
+++ b/tests/test_subdirs/stores/rockstore/rockstore.rst
@@ -1,0 +1,10 @@
+OpenAPI Specification for Rockstore
+===================================
+
+.. swagger-plugin:: ../../specs/rockstore/openapi_specs.yml
+   :id: rockstore-uptree
+   :page-title: Uptree Rocks
+
+.. swagger-plugin:: specs/openapi_childdir.yml
+   :id: pets-downtree
+   :page-title: Downtree Pets

--- a/tests/test_subdirs/stores/rockstore/specs/openapi_childdir.yml
+++ b/tests/test_subdirs/stores/rockstore/specs/openapi_childdir.yml
@@ -1,0 +1,119 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore in Childdir
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+        required: true
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
For a start.  I can follow up with more detail.

* Appending to `html_static_path` didn't do what I thought it did.  It coincidentally worked for tests.
* Preserve the source directory structure in the build output so that we sidestep the risk of clobbering files with the same name.
* Calculate the path from the HTML file to the `_static` directory more carefully.  Add a test that uses two subdirs at different depths.