### PR TITLE
fix: Specifications from parents of Sphinx source directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 5.1.1
+
+* Fixed a bug related to referencing a specification from a parent
+  directory of the Sphinx source directory, such as when documentation
+  is co-located with source code.
+
+  Before this fix, when a specification was several subdirectories
+  from the documentation, the specification could be copied to
+  a parent directory of the build HTML output and prevent the display
+  of the specification.
+
+  With this fix, deeply nested specifications (`../../../../openapi.yaml`)
+  have the `..` values that are parents of the Sphinx source directory
+  replaced with the text `dot-dot`. This fix ensures that deeply
+  nested specifications are copied to a subdirectory of the `_static`
+  directory in the HTML output.
+
 ## 5.1.0
 
 * Refactored copying the specification to the HTML output and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swagger-plugin-for-sphinx"
-version = "5.1.0"
+version = "5.1.1"
 description = "Sphinx plugin which renders a OpenAPI specification with Swagger"
 authors = [{ name = "Kai Harder", email = "kai.harder@sap.com" }]
 readme = "README.md"

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -59,6 +59,9 @@ class SwaggerPluginDirective(SphinxDirective):
             )
 
         relpath, abspath = self.env.relfn2path(self.arguments[0])
+        # Use dot-dot to address referencing specs from parents of the Sphinx source directory.
+        # Otherwise, the spec is copied to a parent of the output directory.
+        relpath = relpath.replace("..", "dot-dot")
         spec = Path(abspath).resolve()
         if not spec.exists():
             raise ExtensionError(


### PR DESCRIPTION
If a spec is referenced with `../../../and-so-on/` to access a file from a parent of the Sphinx
source directory, the resolved path can be
a path that is a parent of the output HTML directory.

By replacing the ".." with "dot-dot" in the output of the Sphinx relfn2path function, this fix
ensures that the spec is copied correctly to
a subdirectory of the output `_static` directory.

For example, expect to see `_static/dot-dot/dot-dot/openapi.yaml`. That path would otherwise be a parent of the output HTML.