### PR TITLE
feat: Add paths and schema text to search index

### DIFF
--- a/news/+cf9dc234.feature.md
+++ b/news/+cf9dc234.feature.md
@@ -1,0 +1,1 @@
+The OpenAPI spec is now indexed for the sphinx search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "sphinx>=8.0,<10",
     "jinja2~=3.0",
     "docutils",
+    "pyyaml~=6.0",
     "typing_extensions~=4.5",
 ]
 description = "Sphinx plugin which renders a OpenAPI specification with Swagger"

--- a/swagger_plugin_for_sphinx/_openapi_index.py
+++ b/swagger_plugin_for_sphinx/_openapi_index.py
@@ -8,11 +8,22 @@ from typing import Any
 
 import yaml
 from sphinx.errors import ExtensionError
+from sphinx.util import logging
 
 _HTTP_METHODS = frozenset(
     {"get", "post", "put", "patch", "delete", "head", "options", "trace"},
 )
 _DESCRIPTION_MAX_LEN = 500
+logger = logging.getLogger(__name__)
+
+
+def _check_for_string(val: Any) -> str:
+    """Defensive check for string values in OpenAPI spec fields."""
+    if isinstance(val, str):
+        return val.strip()
+    if val is not None:
+        logger.warning("Expected a string value, got %s: %r", type(val).__name__, val)
+    return ""
 
 
 def _append_description_line(
@@ -21,6 +32,8 @@ def _append_description_line(
     *,
     compare_to: str,
 ) -> None:
+    """Append a description line to the text for the search index."""
+    # If the description is identical to the summary/title, skip it.
     if isinstance(desc, str) and desc.strip() and desc.strip() != compare_to.strip():
         snippet = desc.strip()
         if len(snippet) > _DESCRIPTION_MAX_LEN:
@@ -28,12 +41,15 @@ def _append_description_line(
         lines.append(snippet)
 
 
-def _schema_map_from_spec(spec: dict[str, Any]) -> dict[str, Any] | None:
+def _get_schemas(spec: dict[str, Any]) -> dict[str, Any] | None:
+    """Return text from the schema section of the spec for use in the search index."""
+    # Components are part of the OpenAPI 3.x specification.
     components = spec.get("components")
     if isinstance(components, dict):
         schemas = components.get("schemas")
         if isinstance(schemas, dict):
             return schemas
+    # For 2.0, use top-level definitions.
     definitions = spec.get("definitions")
     if isinstance(definitions, dict):
         return definitions
@@ -41,26 +57,26 @@ def _schema_map_from_spec(spec: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def _extend_schema_lines(lines: list[str], spec: dict[str, Any]) -> None:
-    schemas = _schema_map_from_spec(spec)
+    """Add key fields from the schema objects to the search index."""
+    schemas = _get_schemas(spec)
     if not schemas:
         return
-    for name in sorted(schemas):
-        body = schemas[name]
-        if not isinstance(body, dict):
+    for name in schemas:  # "Pet"
+        schema = schemas[name]  # {"type": "object", "title": "A Pet", ...}
+        if not isinstance(schema, dict):
             continue
-        title = body.get("title")
-        title_str = title.strip() if isinstance(title, str) and title.strip() else ""
-        subtitle = title_str if title_str and title_str != str(name) else ""
-        lines.append(f"Schema {name}" + (f" — {subtitle}" if subtitle else ""))
+        title_str = _check_for_string(schema.get("title"))
+        suffix = f" — {title_str}" if title_str and title_str != str(name) else ""
+        lines.append(f"Schema {name}{suffix}")  # "Schema Pet — A Pet"
         _append_description_line(
             lines,
-            body.get("description"),
+            schema.get("description"),
             compare_to=title_str or str(name),
         )
 
 
-def load_openapi_mapping(path: Path) -> dict[str, Any]:
-    """Load a JSON or YAML OpenAPI file into a mapping."""
+def load_openapi_file(path: Path) -> dict[str, Any]:
+    """Load a JSON or YAML OpenAPI file."""
     raw = path.read_text(encoding="utf-8")
     try:
         data: Any = json.loads(raw)
@@ -75,39 +91,40 @@ def load_openapi_mapping(path: Path) -> dict[str, Any]:
 
 
 def openapi_lines_for_search(spec: dict[str, Any]) -> list[str]:
-    """Build human-readable lines for search: API title, operations, and schemas."""
+    """Build human-readable lines from the spec for the search index.
+
+    Get the API title, operations, and schemas.
+    """
     lines: list[str] = []
+    # Get the API title and version.
     info = spec.get("info")
     if isinstance(info, dict):
         title = info.get("title")
         if title:
             version = info.get("version")
             lines.append(f"{title} {version}" if version else str(title))
+    # Get the endpoints and methods.
     paths = spec.get("paths")
     if isinstance(paths, dict):
-        for path in sorted(paths):
-            path_item = paths[path]
-            if not isinstance(path_item, dict):
+        for path in paths:  # "/pets"
+            if not isinstance(paths[path], dict):
                 continue
-            for method in sorted(path_item, key=str.lower):
+            for method in paths[path]:  # "get"
                 if str(method).lower() not in _HTTP_METHODS:
                     continue
-                op = path_item[method]
+                op = paths[path][method]  # {"summary": "List all pets", ...}
                 if not isinstance(op, dict):
                     continue
-                summary = op.get("summary")
-                op_id = op.get("operationId")
-                label = summary if isinstance(summary, str) and summary.strip() else ""
-                if not label and isinstance(op_id, str) and op_id.strip():
-                    label = op_id.strip()
-                upper = str(method).upper()
-                line = f"{upper} {path}" + (f" — {label}" if label else "")
-                lines.append(line)
-                summary_cmp = summary.strip() if isinstance(summary, str) else ""
+                summary = _check_for_string(op.get("summary"))  # "List all pets"
+                label = summary or _check_for_string(op.get("operationId"))
+                suffix = f" — {label}" if label else ""
+                lines.append(
+                    f"{str(method).upper()} {path}{suffix}"
+                )  # "GET /pets — List all pets"
                 _append_description_line(
                     lines,
                     op.get("description"),
-                    compare_to=summary_cmp,
+                    compare_to=summary,
                 )
     _extend_schema_lines(lines, spec)
     return lines

--- a/swagger_plugin_for_sphinx/_openapi_index.py
+++ b/swagger_plugin_for_sphinx/_openapi_index.py
@@ -1,0 +1,113 @@
+"""Derive plain-text lines from an OpenAPI document for search indexing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+from sphinx.errors import ExtensionError
+
+_HTTP_METHODS = frozenset(
+    {"get", "post", "put", "patch", "delete", "head", "options", "trace"},
+)
+_DESCRIPTION_MAX_LEN = 500
+
+
+def _append_description_line(
+    lines: list[str],
+    desc: Any,
+    *,
+    compare_to: str,
+) -> None:
+    if isinstance(desc, str) and desc.strip() and desc.strip() != compare_to.strip():
+        snippet = desc.strip()
+        if len(snippet) > _DESCRIPTION_MAX_LEN:
+            snippet = snippet[: _DESCRIPTION_MAX_LEN - 3] + "..."
+        lines.append(snippet)
+
+
+def _schema_map_from_spec(spec: dict[str, Any]) -> dict[str, Any] | None:
+    components = spec.get("components")
+    if isinstance(components, dict):
+        schemas = components.get("schemas")
+        if isinstance(schemas, dict):
+            return schemas
+    definitions = spec.get("definitions")
+    if isinstance(definitions, dict):
+        return definitions
+    return None
+
+
+def _extend_schema_lines(lines: list[str], spec: dict[str, Any]) -> None:
+    schemas = _schema_map_from_spec(spec)
+    if not schemas:
+        return
+    for name in sorted(schemas):
+        body = schemas[name]
+        if not isinstance(body, dict):
+            continue
+        title = body.get("title")
+        title_str = title.strip() if isinstance(title, str) and title.strip() else ""
+        subtitle = title_str if title_str and title_str != str(name) else ""
+        lines.append(f"Schema {name}" + (f" — {subtitle}" if subtitle else ""))
+        _append_description_line(
+            lines,
+            body.get("description"),
+            compare_to=title_str or str(name),
+        )
+
+
+def load_openapi_mapping(path: Path) -> dict[str, Any]:
+    """Load a JSON or YAML OpenAPI file into a mapping."""
+    raw = path.read_text(encoding="utf-8")
+    try:
+        data: Any = json.loads(raw)
+    except json.JSONDecodeError:
+        try:
+            data = yaml.safe_load(raw)
+        except yaml.YAMLError as exc:
+            raise ExtensionError(f"Could not parse OpenAPI file {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ExtensionError(f"OpenAPI document must be a mapping: {path}")
+    return data
+
+
+def openapi_lines_for_search(spec: dict[str, Any]) -> list[str]:
+    """Build human-readable lines for search: API title, operations, and schemas."""
+    lines: list[str] = []
+    info = spec.get("info")
+    if isinstance(info, dict):
+        title = info.get("title")
+        if title:
+            version = info.get("version")
+            lines.append(f"{title} {version}" if version else str(title))
+    paths = spec.get("paths")
+    if isinstance(paths, dict):
+        for path in sorted(paths):
+            path_item = paths[path]
+            if not isinstance(path_item, dict):
+                continue
+            for method in sorted(path_item, key=str.lower):
+                if str(method).lower() not in _HTTP_METHODS:
+                    continue
+                op = path_item[method]
+                if not isinstance(op, dict):
+                    continue
+                summary = op.get("summary")
+                op_id = op.get("operationId")
+                label = summary if isinstance(summary, str) and summary.strip() else ""
+                if not label and isinstance(op_id, str) and op_id.strip():
+                    label = op_id.strip()
+                upper = str(method).upper()
+                line = f"{upper} {path}" + (f" — {label}" if label else "")
+                lines.append(line)
+                summary_cmp = summary.strip() if isinstance(summary, str) else ""
+                _append_description_line(
+                    lines,
+                    op.get("description"),
+                    compare_to=summary_cmp,
+                )
+    _extend_schema_lines(lines, spec)
+    return lines

--- a/swagger_plugin_for_sphinx/_openapi_index.py
+++ b/swagger_plugin_for_sphinx/_openapi_index.py
@@ -3,37 +3,20 @@
 from __future__ import annotations
 
 import json
+from http import HTTPMethod
 from pathlib import Path
 from typing import Any
 
 import yaml
 from sphinx.errors import ExtensionError
-from sphinx.util import logging
 
-_HTTP_METHODS = frozenset(
-    {"get", "post", "put", "patch", "delete", "head", "options", "trace"},
-)
+_HTTP_METHODS = frozenset(method.value.lower() for method in HTTPMethod)
 _DESCRIPTION_MAX_LEN = 500
-logger = logging.getLogger(__name__)
 
 
-def _check_for_string(val: Any) -> str:
-    """Defensive check for string values in OpenAPI spec fields."""
-    if isinstance(val, str):
-        return val.strip()
-    if val is not None:
-        logger.warning("Expected a string value, got %s: %r", type(val).__name__, val)
-    return ""
-
-
-def _append_description_line(
-    lines: list[str],
-    desc: Any,
-    *,
-    compare_to: str,
-) -> None:
+def _append_description_line(lines: list[str], desc: Any, *, compare_to: str) -> None:
     """Append a description line to the text for the search index."""
-    # If the description is identical to the summary/title, skip it.
+    # Skip if identical to the summary/title to avoid duplication.
     if isinstance(desc, str) and desc.strip() and desc.strip() != compare_to.strip():
         snippet = desc.strip()
         if len(snippet) > _DESCRIPTION_MAX_LEN:
@@ -56,22 +39,20 @@ def _get_schemas(spec: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
-def _extend_schema_lines(lines: list[str], spec: dict[str, Any]) -> None:
+def _extend_schema_lines(spec: dict[str, Any], lines: list[str]) -> None:
     """Add key fields from the schema objects to the search index."""
     schemas = _get_schemas(spec)
     if not schemas:
         return
-    for name in schemas:  # "Pet"
-        schema = schemas[name]  # {"type": "object", "title": "A Pet", ...}
+    for name, schema in schemas.items():
         if not isinstance(schema, dict):
             continue
-        title_str = _check_for_string(schema.get("title"))
+        raw_title = schema.get("title")
+        title_str = raw_title.strip() if isinstance(raw_title, str) else ""
         suffix = f" — {title_str}" if title_str and title_str != str(name) else ""
-        lines.append(f"Schema {name}{suffix}")  # "Schema Pet — A Pet"
+        lines.append(f"Schema {name}{suffix}")
         _append_description_line(
-            lines,
-            schema.get("description"),
-            compare_to=title_str or str(name),
+            lines, schema.get("description"), compare_to=title_str or str(name)
         )
 
 
@@ -90,41 +71,41 @@ def load_openapi_file(path: Path) -> dict[str, Any]:
     return data
 
 
-def openapi_lines_for_search(spec: dict[str, Any]) -> list[str]:
-    """Build human-readable lines from the spec for the search index.
-
-    Get the API title, operations, and schemas.
-    """
-    lines: list[str] = []
-    # Get the API title and version.
+def _handle_openapi_info(spec: dict[str, Any], lines: list[str]) -> None:
     info = spec.get("info")
-    if isinstance(info, dict):
-        title = info.get("title")
-        if title:
-            version = info.get("version")
-            lines.append(f"{title} {version}" if version else str(title))
-    # Get the endpoints and methods.
+    if not isinstance(info, dict):
+        return
+    title = info.get("title")
+    if not title:
+        return
+    version = info.get("version")
+    lines.append(f"{title} {version}" if version else str(title))
+
+
+def _handle_paths(spec: dict[str, Any], lines: list[str]) -> None:
     paths = spec.get("paths")
-    if isinstance(paths, dict):
-        for path in paths:  # "/pets"
-            if not isinstance(paths[path], dict):
+    if not isinstance(paths, dict):
+        return
+    for path, path_item in paths.items():
+        if not isinstance(path_item, dict):
+            continue
+        for method, op in path_item.items():
+            if method.lower() not in _HTTP_METHODS or not isinstance(op, dict):
                 continue
-            for method in paths[path]:  # "get"
-                if str(method).lower() not in _HTTP_METHODS:
-                    continue
-                op = paths[path][method]  # {"summary": "List all pets", ...}
-                if not isinstance(op, dict):
-                    continue
-                summary = _check_for_string(op.get("summary"))  # "List all pets"
-                label = summary or _check_for_string(op.get("operationId"))
-                suffix = f" — {label}" if label else ""
-                lines.append(
-                    f"{str(method).upper()} {path}{suffix}"
-                )  # "GET /pets — List all pets"
-                _append_description_line(
-                    lines,
-                    op.get("description"),
-                    compare_to=summary,
-                )
-    _extend_schema_lines(lines, spec)
+            raw_summary = op.get("summary")
+            summary = raw_summary.strip() if isinstance(raw_summary, str) else ""
+            raw_op_id = op.get("operationId")
+            op_id = raw_op_id.strip() if isinstance(raw_op_id, str) else ""
+            label = summary or op_id
+            suffix = f" — {label}" if label else ""
+            lines.append(f"{method.upper()} {path}{suffix}")
+            _append_description_line(lines, op.get("description"), compare_to=summary)
+
+
+def openapi_lines_for_search(spec: dict[str, Any]) -> list[str]:
+    """Build human-readable lines from the spec for the search index."""
+    lines: list[str] = []
+    _handle_openapi_info(spec, lines)
+    _handle_paths(spec, lines)
+    _extend_schema_lines(spec, lines)
     return lines

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -20,7 +20,7 @@ from sphinx.writers.html5 import HTML5Translator
 from typing_extensions import override
 
 from swagger_plugin_for_sphinx._openapi_index import (
-    load_openapi_mapping,
+    load_openapi_file,
     openapi_lines_for_search,
 )
 
@@ -129,7 +129,8 @@ class SwaggerPluginDirective(SphinxDirective):
         if config["full_page"]:
             return []
 
-        spec_data = load_openapi_mapping(spec)
+        # Add the title, operations, and schema objects to the Sphinx search index.
+        spec_data = load_openapi_file(spec)
         search_lines = openapi_lines_for_search(spec_data)
         index_node = _build_search_index_node(search_lines, self)
 

--- a/swagger_plugin_for_sphinx/_plugin.py
+++ b/swagger_plugin_for_sphinx/_plugin.py
@@ -16,10 +16,40 @@ from sphinx.errors import ExtensionError
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.osutil import copyfile, ensuredir
+from sphinx.writers.html5 import HTML5Translator
 from typing_extensions import override
+
+from swagger_plugin_for_sphinx._openapi_index import (
+    load_openapi_mapping,
+    openapi_lines_for_search,
+)
 
 logger = logging.getLogger(__name__)
 _HERE = Path(__file__).parent.resolve()
+
+
+class SwaggerSearchIndex(nodes.Element):
+    """OpenAPI text for full-text search; not rendered in HTML."""
+
+
+def _visit_swagger_search_index_html(
+    self: HTML5Translator, _node: SwaggerSearchIndex
+) -> None:
+    """Suppress rendering; search indexing walks the doctree separately."""
+    raise nodes.SkipNode()
+
+
+def _build_search_index_node(
+    lines: list[str], directive: SwaggerPluginDirective
+) -> SwaggerSearchIndex:
+    """Wrap *lines* as paragraphs for ``IndexBuilder``, hidden from HTML output."""
+    block = SwaggerSearchIndex()
+    directive.set_source_info(block)
+    for line in lines:
+        para = nodes.paragraph("", line)
+        directive.set_source_info(para)
+        block.append(para)
+    return block
 
 
 class SwaggerPluginDirective(SphinxDirective):
@@ -99,11 +129,15 @@ class SwaggerPluginDirective(SphinxDirective):
         if config["full_page"]:
             return []
 
+        spec_data = load_openapi_mapping(spec)
+        search_lines = openapi_lines_for_search(spec_data)
+        index_node = _build_search_index_node(search_lines, self)
+
         div_id = self.options.get("id", "swagger-ui-container")
         node = nodes.container(ids=[div_id], classes=self.options.get("classes", []))
         self.set_source_info(node)
         config["div_id"] = div_id
-        return [node]
+        return [index_node, node]
 
 
 def add_css_js(
@@ -160,6 +194,8 @@ def render(app: Sphinx) -> Iterator[tuple[Any, ...]]:
 
 def setup(app: Sphinx) -> dict[str, Any]:
     """Setup this plugin."""
+    app.add_node(SwaggerSearchIndex, html=(_visit_swagger_search_index_html, None))
+
     app.add_config_value(
         "swagger_present_uri",
         "https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest/swagger-ui-standalone-preset.js",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -124,6 +124,26 @@ def test_extension(
 
 
 @pytest.mark.integration
+def test_search(host_browser: HostBrowser) -> None:
+    """Search for an OpenAPI operation or schema returns results for the reference pages."""
+    browser = host_browser([])
+
+    browser.get("http://localhost:8000/search.html?q=List+all+pets")
+    time.sleep(5)
+    links = browser.find_elements(By.CSS_SELECTOR, "ul.search li a")
+    hrefs = [href for link in links if (href := link.get_attribute("href"))]
+    assert any("petstore" in href for href in hrefs)
+    assert any("rockstore" in href for href in hrefs)
+
+    browser.get("http://localhost:8000/search.html?q=Schema+Pet")
+    time.sleep(5)
+    links = browser.find_elements(By.CSS_SELECTOR, "ul.search li a")
+    hrefs = [href for link in links if (href := link.get_attribute("href"))]
+    assert any("petstore" in href for href in hrefs)
+    assert any("rockstore" in href for href in hrefs)
+
+
+@pytest.mark.integration
 def test_dirhtml(host_browser: HostBrowser) -> None:
     """Test a dirhtml scenario."""
     browser = host_browser(["-b", "dirhtml"])

--- a/tests/test_openapi_index.py
+++ b/tests/test_openapi_index.py
@@ -8,14 +8,14 @@ import pytest
 from sphinx.errors import ExtensionError
 
 from swagger_plugin_for_sphinx._openapi_index import (
-    load_openapi_mapping,
+    load_openapi_file,
     openapi_lines_for_search,
 )
 
 
 def test_openapi_lines_for_search() -> None:
     spec_path = Path(__file__).with_name("openapi.yml")
-    spec = load_openapi_mapping(spec_path)
+    spec = load_openapi_file(spec_path)
     lines = openapi_lines_for_search(spec)
     assert "Swagger Petstore 1.0.0" in lines
     assert "GET /pets — List all pets" in lines
@@ -180,18 +180,18 @@ def test_load_openapi_invalid_yaml(tmp_path: Path) -> None:
     bad = tmp_path / "bad.yaml"
     bad.write_text("foo: [", encoding="utf-8")
     with pytest.raises(ExtensionError, match="Could not parse"):
-        load_openapi_mapping(bad)
+        load_openapi_file(bad)
 
 
 def test_load_openapi_not_mapping(tmp_path: Path) -> None:
     listed = tmp_path / "list.yaml"
     listed.write_text("- a\n- b\n", encoding="utf-8")
     with pytest.raises(ExtensionError, match="must be a mapping"):
-        load_openapi_mapping(listed)
+        load_openapi_file(listed)
 
 
 def test_load_json(tmp_path: Path) -> None:
     j = tmp_path / "x.json"
     j.write_text('{"info": {"title": "T"}, "paths": {}}', encoding="utf-8")
-    spec = load_openapi_mapping(j)
+    spec = load_openapi_file(j)
     assert openapi_lines_for_search(spec) == ["T"]

--- a/tests/test_openapi_index.py
+++ b/tests/test_openapi_index.py
@@ -1,0 +1,197 @@
+"""Tests for OpenAPI → search lines."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sphinx.errors import ExtensionError
+
+from swagger_plugin_for_sphinx._openapi_index import (
+    load_openapi_mapping,
+    openapi_lines_for_search,
+)
+
+
+def test_openapi_lines_for_search() -> None:
+    spec_path = Path(__file__).with_name("openapi.yml")
+    spec = load_openapi_mapping(spec_path)
+    lines = openapi_lines_for_search(spec)
+    assert "Swagger Petstore 1.0.0" in lines
+    assert "GET /pets — List all pets" in lines
+    assert "POST /pets — Create a pet" in lines
+    assert "GET /pets/{petId} — Info for a specific pet" in lines
+    assert "Schema Error" in lines
+    assert "Schema Pet" in lines
+    assert "Schema Pets" in lines
+
+
+def test_openapi_lines_title_without_version() -> None:
+    lines = openapi_lines_for_search({"info": {"title": "OnlyTitle"}})
+    assert lines == ["OnlyTitle"]
+
+
+def test_openapi_lines_paths_not_mapping() -> None:
+    lines = openapi_lines_for_search({"info": {"title": "T"}, "paths": []})
+    assert lines == ["T"]
+
+
+def test_openapi_lines_skips_bad_path_or_operation() -> None:
+    lines = openapi_lines_for_search(
+        {
+            "paths": {
+                "/bad-item": "not-a-mapping",
+                "/b": {"get": "not-an-operation"},
+            },
+        },
+    )
+    assert not lines
+
+
+def test_openapi_lines_operation_id_without_summary() -> None:
+    lines = openapi_lines_for_search(
+        {"paths": {"/x": {"get": {"operationId": "fetchX"}}}},
+    )
+    assert lines == ["GET /x — fetchX"]
+
+
+def test_openapi_lines_non_method_path_keys_skipped() -> None:
+    lines = openapi_lines_for_search(
+        {
+            "paths": {
+                "/x": {
+                    "parameters": [],
+                    "get": {"summary": "G"},
+                },
+            },
+        },
+    )
+    assert lines == ["GET /x — G"]
+
+
+def test_openapi_lines_info_dict_but_no_title() -> None:
+    assert not openapi_lines_for_search({"info": {}})
+
+
+def test_openapi_lines_schemas_when_paths_not_mapping() -> None:
+    lines = openapi_lines_for_search(
+        {
+            "info": {"title": "T"},
+            "paths": [],
+            "components": {"schemas": {"Pet": {"type": "object"}}},
+        },
+    )
+    assert lines[0] == "T"
+    assert "Schema Pet" in lines
+
+
+def test_openapi_lines_swagger2_definitions() -> None:
+    lines = openapi_lines_for_search(
+        {
+            "swagger": "2.0",
+            "definitions": {"Widget": {"type": "object", "title": "W"}},
+        },
+    )
+    assert "Schema Widget — W" in lines
+
+
+def test_openapi_lines_schema_description() -> None:
+    lines = openapi_lines_for_search(
+        {
+            "components": {
+                "schemas": {
+                    "M": {
+                        "type": "object",
+                        "description": "A model for things.",
+                    },
+                },
+            },
+        },
+    )
+    assert "Schema M" in lines
+    assert "A model for things." in lines
+
+
+def test_openapi_lines_skips_non_mapping_schema_body() -> None:
+    lines = openapi_lines_for_search(
+        {"components": {"schemas": {"X": "broken"}}},
+    )
+    assert not lines
+
+
+def test_openapi_lines_components_not_dict() -> None:
+    lines = openapi_lines_for_search({"components": "no", "paths": {}})
+    assert not lines
+
+
+def test_openapi_lines_definitions_when_component_schemas_invalid() -> None:
+    lines = openapi_lines_for_search(
+        {
+            "components": {"schemas": "not-a-map"},
+            "definitions": {"D": {"type": "object"}},
+        },
+    )
+    assert lines == ["Schema D"]
+
+
+def test_openapi_lines_description_omitted_when_same_as_summary() -> None:
+    lines = openapi_lines_for_search(
+        {
+            "paths": {
+                "/x": {"get": {"summary": "Same", "description": "Same"}},
+            },
+        },
+    )
+    assert lines == ["GET /x — Same"]
+
+
+def test_openapi_lines_description_truncated() -> None:
+    long_desc = "a" * 600
+    lines = openapi_lines_for_search(
+        {
+            "paths": {
+                "/x": {
+                    "get": {"summary": "S", "description": long_desc},
+                },
+            },
+        },
+    )
+    assert "GET /x — S" in lines
+    excerpt = [line for line in lines if line.startswith("a")]
+    assert len(excerpt) == 1
+    assert excerpt[0].endswith("...")
+    assert len(excerpt[0]) == 500
+
+
+def test_openapi_lines_extra_description_line() -> None:
+    lines = openapi_lines_for_search(
+        {
+            "paths": {
+                "/x": {
+                    "get": {"summary": "S", "description": "Extra detail"},
+                },
+            },
+        },
+    )
+    assert lines == ["GET /x — S", "Extra detail"]
+
+
+def test_load_openapi_invalid_yaml(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("foo: [", encoding="utf-8")
+    with pytest.raises(ExtensionError, match="Could not parse"):
+        load_openapi_mapping(bad)
+
+
+def test_load_openapi_not_mapping(tmp_path: Path) -> None:
+    listed = tmp_path / "list.yaml"
+    listed.write_text("- a\n- b\n", encoding="utf-8")
+    with pytest.raises(ExtensionError, match="must be a mapping"):
+        load_openapi_mapping(listed)
+
+
+def test_load_json(tmp_path: Path) -> None:
+    j = tmp_path / "x.json"
+    j.write_text('{"info": {"title": "T"}, "paths": {}}', encoding="utf-8")
+    spec = load_openapi_mapping(j)
+    assert openapi_lines_for_search(spec) == ["T"]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -165,8 +165,8 @@ def test_openapi_search_index_not_in_html(
     assert "Schema Pet" not in html
 
     searchindex = (tmp_path / "build" / "searchindex.js").read_text(encoding="utf-8")
-    assert "list" in searchindex.lower()
-    assert "pet" in searchindex.lower()
+    assert "list" in searchindex  # from "List all pets"
+    assert "schema" in searchindex  # from "Schema Pet"
 
 
 def test_swagger_plugin_directive_same_dir(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -153,6 +153,22 @@ def test_swagger_options(sphinx_runner: SphinxRunner, tmp_path: Path) -> None:
     assert html.count("SwaggerUIBundle(options)") == 1
 
 
+def test_openapi_search_index_not_in_html(
+    sphinx_runner: SphinxRunner, tmp_path: Path
+) -> None:
+    """Operation text feeds the HTML search index but is skipped for page body."""
+    sphinx_runner(".. swagger-plugin:: openapi.yaml")
+    html = read_api_html(tmp_path)
+    assert "List all pets" not in html
+    assert "Info for a specific pet" not in html
+    assert "Swagger Petstore" not in html
+    assert "Schema Pet" not in html
+
+    searchindex = (tmp_path / "build" / "searchindex.js").read_text(encoding="utf-8")
+    assert "list" in searchindex.lower()
+    assert "pet" in searchindex.lower()
+
+
 def test_swagger_plugin_directive_same_dir(
     sphinx_runner: SphinxRunner, tmp_path: Path
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1532,6 +1532,7 @@ dependencies = [
     { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jinja2" },
+    { name = "pyyaml" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -1570,6 +1571,7 @@ test = [
 requires-dist = [
     { name = "docutils" },
     { name = "jinja2", specifier = "~=3.0" },
+    { name = "pyyaml", specifier = "~=6.0" },
     { name = "sphinx", specifier = ">=8.0,<10" },
     { name = "typing-extensions", specifier = "~=4.5" },
 ]


### PR DESCRIPTION
The goal of this PR is to take text from the API spec, such as the endpoint names and schema objects, and make that available to Sphinx for search.

Because the spec reference is dynamically created when viewing the page, Sphinx has no way of offering a search hit for "Pet" or "Pets."  With this addition, the search page includes a link to the API reference page.  It's a small step, but worth taking imo.

PLMK what I can clarify and any changes you'd like.